### PR TITLE
Compatible with Bioconductor 3.8 & Bug fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rvcheck
 Type: Package
 Title: R/Package Version Check
-Version: 0.1.1
+Version: 0.1.2
 Authors@R: c(person(given = "Guangchuang", family = "Yu",
 	   	    email = "guangchuangyu@gmail.com",
 		    role  = c("aut", "cre"))

--- a/R/check_pkg.R
+++ b/R/check_pkg.R
@@ -77,12 +77,14 @@ check_github_gitlab <- function(pkg, repo="github") {
 ##' check_bioc('ggtree')
 ##' }
 ##' @author Guangchuang Yu
-check_bioc <- function(pkg="BiocInstaller") {
-    msg <- paste("## try http:// if https:// URLs are not supported",
-                 'source("https://www.bioconductor.org/biocLite.R")',
-                 paste0('biocLite("', pkg, '")'), sep="\n")
-
-    check_release("https://bioconductor.org/packages/", pkg, msg)
+check_bioc <- function(pkg="BiocManager") {
+    msg <- paste('install.packages("BiocManager")',
+                 paste0('BiocManager::install("', pkg, '")'), sep="\n")
+    if (pkg == "BiocManager"){
+        check_cran(pkg)
+    }else{
+        check_release("https://bioconductor.org/packages/", pkg, msg)
+    }
 }
 
 ##' check latest release version of cran package
@@ -111,7 +113,7 @@ check_release <- function(base_url, pkg, msg) {
 
     url <- paste0(base_url, pkg)
     x <- readLines(url)
-    remote_version <- gsub("\\D+([\\.0-9]+)\\D+", '\\1', x[grep("Version", x)+1])
+    remote_version <- gsub("\\D+([\\.0-9]+)\\D+", '\\1', x[grep("<td>Version:</td>", x)+1])
 
     res <- list(package = pkg,
                 installed_version = as.character(installed_version),

--- a/R/check_pkg.R
+++ b/R/check_pkg.R
@@ -113,7 +113,7 @@ check_release <- function(base_url, pkg, msg) {
 
     url <- paste0(base_url, pkg)
     x <- readLines(url)
-    remote_version <- gsub("\\D+([\\.0-9]+)\\D+", '\\1', x[grep("<td>Version:</td>", x)+1])
+    remote_version <- gsub("\\D+([\\.0-9-]+)\\D+", '\\1', x[grep("<td>Version:</td>", x)+1])
 
     res <- list(package = pkg,
                 installed_version = as.character(installed_version),

--- a/R/update_all.R
+++ b/R/update_all.R
@@ -44,7 +44,7 @@ update_cran <- function() {
 }
 
 update_bioc <- function() {
-    pkg <- "BiocInstaller"
+    pkg <- "BiocManager"
     bioc_version <- tryCatch(packageVersion(pkg), error=function(e) NULL)
     if (is.null(bioc_version)) {
         message("no Bioconductor packages found...")
@@ -53,17 +53,17 @@ update_bioc <- function() {
         if (is.na(bioc)) {
             message("You are using devel branch of Bioconductor...")
         } else if (!bioc) {
-            message("BiocInstaller is out of date...")
-            message("Upgrading BiocInstaller...")
+            message("BiocManager is out of date...")
+            message("Upgrading BiocManager...")
             if (pkg %in% loadedNamespaces())
-                detach("package:BiocInstaller", character.only=TRUE)
-            remove.packages("BiocInstaller")
-            source("https://www.bioconductor.org/biocLite.R")
+                detach("package:BiocManager", character.only=TRUE)
+            remove.packages("BiocManager")
+            install.packages("BiocManager")
         }
         message("upgrading BioC packages...")
         suppressPackageStartupMessages(require(pkg, character.only = TRUE))
-        biocLite <- eval(parse(text="biocLite"))
-        biocLite(ask=FALSE, checkBuilt=TRUE)
+        install <- eval(parse(text="BiocManager::install"))
+        install(ask=FALSE, checkBuilt=TRUE)
     }
 }
 

--- a/man/check_bioc.Rd
+++ b/man/check_bioc.Rd
@@ -4,7 +4,7 @@
 \alias{check_bioc}
 \title{check_bioc}
 \usage{
-check_bioc(pkg = "BiocInstaller")
+check_bioc(pkg = "BiocManager")
 }
 \arguments{
 \item{pkg}{package name}


### PR DESCRIPTION
现在应该可以正常更新 Bioconductor 3.8 的包。

Bug fix：
check_pkg 中查找 Version 时，正则表达式有点太松了，导致有时出现获取不准确的情况。如 check_cran("rvcheck") 就会出错。因此，将匹配条件改的严谨了一些。
另外，package Version 中也常常使用 “-”（如 lattice，RColorBrewer等），为此将正则表达式中匹配版本号的部分修订了一下，加入了“-”字符。